### PR TITLE
Updates for Travis builds. Fixes #1059.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+env:
+- DOCKER_COMPOSE_VERSION=1.28.6
 language: python
 python:
 - '3.6'
@@ -5,6 +7,10 @@ sudo: required
 services:
 - docker
 before_install:
+- sudo rm /usr/local/bin/docker-compose
+- curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+- chmod +x docker-compose
+- sudo mv docker-compose /usr/local/bin
 - docker --version
 - docker-compose --version
 - docker-compose -f docker/ci.docker-compose.yml pull

--- a/docker/ci.docker-compose.yml
+++ b/docker/ci.docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rabbit:
-      image: rabbitmq@sha256:397382d2b222f3a298a6c74e93f348fb16f9a7fde2c02ba14122624d852daae3
+      image: rabbitmq@sha256:d374d705b3f16e3f0ee34ea14d8599cb4c1f1604ae6deef5fefbaf063d0bb9c6
       environment:
           - TZ=America/New_York
           - RABBITMQ_DEFAULT_USER=sfm_user

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,8 +8,6 @@ try:
 except ImportError:
     WEIBO_ACCESS_TOKEN = os.environ.get("WEIBO_ACCESS_TOKEN")
 
-print("XXXXXX Token is", WEIBO_ACCESS_TOKEN)
-
 test_config_available = True if WEIBO_ACCESS_TOKEN else False
 
 mq_port_available = True

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,18 +4,20 @@ import os
 import socket
 
 try:
-    from test_config import *
+    from .test_config import *
 except ImportError:
     WEIBO_ACCESS_TOKEN = os.environ.get("WEIBO_ACCESS_TOKEN")
+
+print("XXXXXX Token is", WEIBO_ACCESS_TOKEN)
 
 test_config_available = True if WEIBO_ACCESS_TOKEN else False
 
 mq_port_available = True
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-try:
-    s.connect(("mq", 5672))
-except socket.error:
-    mq_port_available = False
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    try:
+        s.connect(("mq", 5672))
+    except socket.error:
+        mq_port_available = False
 
 mq_username = os.environ.get("RABBITMQ_USER")
 mq_password = os.environ.get("RABBITMQ_PASSWORD")


### PR DESCRIPTION
Run unittests and integrations tests using `tests/ci.docker-compose.yml` with a valid Weibo API key in `tests/test_config.py`.

If you don't have a Weibo API key, it might be enough to review the code, run unittests outside the docker container, and rely on the credentials stored in an environment variable in Travis settings. 